### PR TITLE
chore!: require Node.js v14+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["6", "latest"]
+        node-version: ["14", "latest"]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3


### PR DESCRIPTION
We'll be cutting a major release to bump to v1.0.0; so might as well drop old Node versions while we're at it.