### PR TITLE
feat: use platform-independent `randomBytes`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["14", "latest"]
+        node-version: ["18.19.0", "latest"]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -23,13 +23,7 @@
   },
   "devDependencies": {
     "@exodus/test": "^1.0.0-rc.63",
-    "babel-eslint": "^7.2.1",
-    "make-dir-cli": "^3.0.0",
     "standard": "^10.0.0"
-  },
-  "standard": {
-    "parser": "babel-eslint",
-    "ignore": "lib"
   },
   "dependencies": {
     "@exodus/crypto": "^1.0.0-rc.14"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "author": "Exodus Movement, Inc.",
-  "main": "./lib/index.js",
+  "main": "./src/index.js",
   "files": [
     "src/"
   ],
@@ -17,24 +17,21 @@
     "url": "git+https://github.com/ExodusMovement/buffer-noise.git"
   },
   "scripts": {
-    "build": "make-dir lib && flow-remove-types ./src/index.js > ./lib/index.js",
     "lint": "standard",
-    "prepare": "npm run build",
-    "pretest": "npm run build",
-    "test": "npm run lint && flow check && npm run unit",
-    "unit": "tape -r flow-remove-types/register ./test/index.js | tf-spec"
+    "test": "npm run lint && npm run unit",
+    "unit": "exodus-test"
   },
   "devDependencies": {
-    "@tap-format/spec": "^0.2.0",
+    "@exodus/test": "^1.0.0-rc.63",
     "babel-eslint": "^7.2.1",
-    "flow-bin": "^0.43.0",
-    "flow-remove-types": "^1.2.0",
     "make-dir-cli": "^3.0.0",
-    "standard": "^10.0.0",
-    "tape": "^4.6.3"
+    "standard": "^10.0.0"
   },
   "standard": {
     "parser": "babel-eslint",
     "ignore": "lib"
+  },
+  "dependencies": {
+    "@exodus/crypto": "^1.0.0-rc.14"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const { randomBytes } = require('@exodus/crypto/randomBytes')
 
 /**
  * @param {number} size
- * @return {Uint8Array|*|{expand(Buffer): Buffer, shrink(Buffer): Buffer}}
+ * @returns {{expand(Buffer): Buffer, shrink(Buffer): Buffer}}
  */
 module.exports = function (size) {
   return {

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,18 @@
-// @flow
-const crypto = require('crypto')
+const { randomBytes } = require('@exodus/crypto/randomBytes')
 
-module.exports = function (size: number): Object {
+/**
+ * @param {number} size
+ * @return {Uint8Array|*|{expand(Buffer): Buffer, shrink(Buffer): Buffer}}
+ */
+module.exports = function (size) {
   return {
-    expand (data: Buffer): Buffer {
-      const buffer = crypto.randomBytes(data.length < size - 4 ? size : data.length + 4)
+    expand (data) {
+      const buffer = randomBytes(data.length < size - 4 ? size : data.length + 4)
       buffer.writeUInt32BE(data.length, 0)
       data.copy(buffer, 4, 0)
       return buffer
     },
-    shrink (buffer: Buffer): Buffer {
+    shrink (buffer) {
       const dataLen = buffer.readUInt32BE(0)
       return buffer.slice(4, dataLen + 4)
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,4 @@
-const test = require('tape')
+const test = require('@exodus/test/tape')
 const crypto = require('crypto')
 const createExpander = require('..')
 


### PR DESCRIPTION
Also
- removes flow
- removes the build step
- use exodus-test